### PR TITLE
Add object ids

### DIFF
--- a/csfunctions/objects/document.py
+++ b/csfunctions/objects/document.py
@@ -69,6 +69,7 @@ class Document(BaseObject):
     cdb_m2date: datetime | None = Field(None, description="File Last Saved on")
     z_art: str | None = Field(None, description="Document Type")
     mapped_materialnr_erp: str | None = Field(None, description="Materialnumber ERP")
+    cdb_object_id: str | None = Field(None, description="Object ID")
 
     files: list[File] = Field([], description="Files attached to the document")
 

--- a/csfunctions/objects/engineering_change.py
+++ b/csfunctions/objects/engineering_change.py
@@ -21,6 +21,7 @@ class EngineeringChange(BaseObject):
     status: int = Field(..., description="Status")
     title: str | None = Field("", description="Title")
     template_ec_id: str | None = Field("", description="Template ID")
+    cdb_object_id: str | None = Field(None, description="Object ID")
 
     c_department: str | None = Field("", description="Department")
     c_description: str | None = Field("", description="Description")

--- a/json_schemas/request.json
+++ b/json_schemas/request.json
@@ -677,6 +677,19 @@
           "description": "Materialnumber ERP",
           "title": "Mapped Materialnr Erp"
         },
+        "cdb_object_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Object ID",
+          "title": "Cdb Object Id"
+        },
         "files": {
           "default": [],
           "description": "Files attached to the document",
@@ -941,6 +954,19 @@
           "default": "",
           "description": "Template ID",
           "title": "Template Ec Id"
+        },
+        "cdb_object_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Object ID",
+          "title": "Cdb Object Id"
         },
         "c_department": {
           "anyOf": [


### PR DESCRIPTION
Adds object_ids to documents and ec.
Needed to link Objects Contained in Workflow trigger Event to log.