### PR TITLE
Refactor event names

### DIFF
--- a/csfunctions/events/__init__.py
+++ b/csfunctions/events/__init__.py
@@ -2,35 +2,35 @@ from typing import Annotated, Union
 
 from pydantic import Field
 
-from .dialog_data import DocumentReleaseDialogData, PartReleaseDialogData
+from .dialog_data import DocumentReleasedDialogData, PartReleasedDialogData
 from .document_create_check import DocumentCreateCheckData, DocumentCreateCheckEvent
 from .document_field_calculation import DocumentFieldCalculationData, DocumentFieldCalculationEvent
 from .document_modify_check import DocumentModifyCheckData, DocumentModifyCheckEvent
-from .document_release import DocumentReleaseData, DocumentReleaseEvent
 from .document_release_check import DocumentReleaseCheckData, DocumentReleaseCheckEvent
+from .document_released import DocumentReleasedData, DocumentReleasedEvent
 from .dummy import DummyEvent, DummyEventData
-from .engineering_change_release import EngineeringChangeRelease, EngineeringChangeReleaseData
-from .engineering_change_release_check import EngineeringChangeReleaseCheck, EngineeringChangeReleaseCheckData
+from .engineering_change_release_check import EngineeringChangeReleaseCheckData, EngineeringChangeReleaseCheckEvent
+from .engineering_change_released import EngineeringChangeReleasedData, EngineeringChangeReleasedEvent
 from .field_value_calculation import FieldValueCalculationData, FieldValueCalculationEvent
 from .part_create_check import PartCreateCheckData, PartCreateCheckEvent
 from .part_field_calculation import PartFieldCalculationData, PartFieldCalculationEvent
 from .part_modify_check import PartModifyCheckData, PartModifyCheckEvent
-from .part_release import PartReleaseData, PartReleaseEvent
 from .part_release_check import PartReleaseCheckData, PartReleaseCheckEvent
+from .part_released import PartReleasedData, PartReleasedEvent
 from .workflow_task_trigger import WorkflowTaskTriggerEvent, WorkflowTaskTriggerEventData
 
 Event = Annotated[
     Union[
-        DocumentReleaseEvent,
+        DocumentReleasedEvent,
         DocumentReleaseCheckEvent,
         DocumentFieldCalculationEvent,
-        PartReleaseEvent,
+        PartReleasedEvent,
         PartReleaseCheckEvent,
         PartFieldCalculationEvent,
         FieldValueCalculationEvent,
         DummyEvent,
-        EngineeringChangeRelease,
-        EngineeringChangeReleaseCheck,
+        EngineeringChangeReleasedEvent,
+        EngineeringChangeReleaseCheckEvent,
         WorkflowTaskTriggerEvent,
         DocumentCreateCheckEvent,
         DocumentModifyCheckEvent,
@@ -40,15 +40,15 @@ Event = Annotated[
     Field(discriminator="name"),
 ]
 EventData = Union[
-    DocumentReleaseData,
+    DocumentReleasedData,
     DocumentReleaseCheckData,
     DocumentFieldCalculationData,
-    PartReleaseData,
+    PartReleasedData,
     PartReleaseCheckData,
     PartFieldCalculationData,
     FieldValueCalculationData,
     DummyEventData,
-    EngineeringChangeReleaseData,
+    EngineeringChangeReleasedData,
     EngineeringChangeReleaseCheckData,
     WorkflowTaskTriggerEventData,
     DocumentCreateCheckData,
@@ -58,29 +58,29 @@ EventData = Union[
 ]
 
 __all__ = [
-    "DocumentReleaseEvent",
+    "DocumentReleasedEvent",
     "DocumentReleaseCheckEvent",
     "DocumentFieldCalculationEvent",
-    "PartReleaseEvent",
+    "PartReleasedEvent",
     "PartReleaseCheckEvent",
     "PartFieldCalculationEvent",
     "FieldValueCalculationEvent",
     "DummyEvent",
-    "EngineeringChangeRelease",
-    "EngineeringChangeReleaseCheck",
+    "EngineeringChangeReleasedEvent",
+    "EngineeringChangeReleaseCheckEvent",
     "WorkflowTaskTriggerEvent",
-    "DocumentReleaseData",
+    "DocumentReleasedData",
     "DocumentReleaseCheckData",
     "DocumentFieldCalculationData",
-    "PartReleaseData",
+    "PartReleasedData",
     "PartReleaseCheckData",
     "FieldValueCalculationData",
     "DummyEventData",
-    "EngineeringChangeReleaseData",
+    "EngineeringChangeReleasedData",
     "EngineeringChangeReleaseCheckData",
     "WorkflowTaskTriggerEventData",
-    "DocumentReleaseDialogData",
-    "PartReleaseDialogData",
+    "DocumentReleasedDialogData",
+    "PartReleasedDialogData",
     "PartFieldCalculationData",
     "DocumentCreateCheckData",
     "DocumentCreateCheckEvent",

--- a/csfunctions/events/base.py
+++ b/csfunctions/events/base.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel, Field
 
 class EventNames(str, Enum):
     DUMMY = "dummy"
-    DOCUMENT_RELEASE = "document_release"
+    DOCUMENT_RELEASED = "document_released"
     DOCUMENT_RELEASE_CHECK = "document_release_check"
     DOCUMENT_FIELD_CALCULATION = "document_field_calculation"
-    PART_RELEASE = "part_release"
+    PART_RELEASED = "part_released"
     PART_RELEASE_CHECK = "part_release_check"
     PART_FIELD_CALCULATION = "part_field_calculation"
-    ENGINEERING_CHANGE_RELEASE = "engineering_change_release"
+    ENGINEERING_CHANGE_RELEASED = "engineering_change_released"
     ENGINEERING_CHANGE_RELEASE_CHECK = "engineering_change_release_check"
     FIELD_VALUE_CALCULATION = "field_value_calculation"
     WORKFLOW_TASK_TRIGGER = "workflow_task_trigger"

--- a/csfunctions/events/dialog_data.py
+++ b/csfunctions/events/dialog_data.py
@@ -3,13 +3,13 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 
-class DocumentReleaseDialogData(BaseModel):
+class DocumentReleasedDialogData(BaseModel):
     dialog_type: Literal["document_release"] = "document_release"
     cdbprot_remark: str | None = Field(None, description="remark")
     cdb_ec_id: str | None = Field(None, description="Engineering Change ID")
 
 
-class PartReleaseDialogData(BaseModel):
+class PartReleasedDialogData(BaseModel):
     dialog_type: Literal["part_release"] = "part_release"
     cdbprot_remark: str | None = Field("", description="remark")
     cdb_ec_id: str | None = Field("", description="Engineering Change ID")

--- a/csfunctions/events/document_create_check.py
+++ b/csfunctions/events/document_create_check.py
@@ -9,7 +9,7 @@ from .base import BaseEvent, EventNames
 
 class DocumentCreateCheckData(BaseModel):
     documents: list[Document] = Field(..., description="List of documents that are about to be created")
-    linked_parts: list[Part] = Field(..., description="List of parts that belong to the documents")
+    parts: list[Part] = Field(..., description="List of parts that belong to the documents")
 
 
 class DocumentCreateCheckEvent(BaseEvent):

--- a/csfunctions/events/document_field_calculation.py
+++ b/csfunctions/events/document_field_calculation.py
@@ -10,7 +10,7 @@ from .base import BaseEvent, EventNames
 class DocumentFieldCalculationData(BaseModel):
     document: Document = Field(..., description="Current state of the document")
     action: Literal["create", "modify", "copy", "index"] = Field(..., description="Action being performed")
-    linked_parts: list[Part] = Field(..., description="Parts that belong to the document")
+    parts: list[Part] = Field(..., description="Parts that belong to the document")
 
 
 class DocumentFieldCalculationEvent(BaseEvent):

--- a/csfunctions/events/document_modify_check.py
+++ b/csfunctions/events/document_modify_check.py
@@ -9,7 +9,7 @@ from .base import BaseEvent, EventNames
 
 class DocumentModifyCheckData(BaseModel):
     documents: list[Document] = Field(..., description="List of documents that are about to be modified")
-    linked_parts: list[Part] = Field(..., description="List of parts that belong to the documents")
+    parts: list[Part] = Field(..., description="List of parts that belong to the documents")
 
 
 class DocumentModifyCheckEvent(BaseEvent):

--- a/csfunctions/events/document_release_check.py
+++ b/csfunctions/events/document_release_check.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel, Field
 from csfunctions.objects import Document, Part
 
 from .base import BaseEvent, EventNames
-from .dialog_data import DocumentReleaseDialogData
+from .dialog_data import DocumentReleasedDialogData
 
 
 class DocumentReleaseCheckData(BaseModel):
     documents: list[Document] = Field(..., description="List of documents that will be released.")
     attached_parts: list[Part] = Field(..., description="List of parts that belong to the documents")
-    dialog_data: DocumentReleaseDialogData
+    dialog_data: DocumentReleasedDialogData
 
 
 class DocumentReleaseCheckEvent(BaseEvent):

--- a/csfunctions/events/document_release_check.py
+++ b/csfunctions/events/document_release_check.py
@@ -10,7 +10,7 @@ from .dialog_data import DocumentReleasedDialogData
 
 class DocumentReleaseCheckData(BaseModel):
     documents: list[Document] = Field(..., description="List of documents that will be released.")
-    attached_parts: list[Part] = Field(..., description="List of parts that belong to the documents")
+    parts: list[Part] = Field(..., description="List of parts that belong to the documents")
     dialog_data: DocumentReleasedDialogData
 
 

--- a/csfunctions/events/document_released.py
+++ b/csfunctions/events/document_released.py
@@ -5,15 +5,15 @@ from pydantic import BaseModel, Field
 from csfunctions.objects import Document, Part
 
 from .base import BaseEvent, EventNames
-from .dialog_data import DocumentReleaseDialogData
+from .dialog_data import DocumentReleasedDialogData
 
 
-class DocumentReleaseData(BaseModel):
+class DocumentReleasedData(BaseModel):
     documents: list[Document] = Field(..., description="List of documents that were released.")
     parts: list[Part] = Field(..., description="List of parts that belong to the released documents")
-    dialog_data: DocumentReleaseDialogData
+    dialog_data: DocumentReleasedDialogData
 
 
-class DocumentReleaseEvent(BaseEvent):
-    name: Literal[EventNames.DOCUMENT_RELEASE] = EventNames.DOCUMENT_RELEASE
-    data: DocumentReleaseData
+class DocumentReleasedEvent(BaseEvent):
+    name: Literal[EventNames.DOCUMENT_RELEASED] = EventNames.DOCUMENT_RELEASED
+    data: DocumentReleasedData

--- a/csfunctions/events/engineering_change_release_check.py
+++ b/csfunctions/events/engineering_change_release_check.py
@@ -15,6 +15,6 @@ class EngineeringChangeReleaseCheckData(BaseModel):
     )
 
 
-class EngineeringChangeReleaseCheck(BaseEvent):
+class EngineeringChangeReleaseCheckEvent(BaseEvent):
     name: Literal[EventNames.ENGINEERING_CHANGE_RELEASE_CHECK] = EventNames.ENGINEERING_CHANGE_RELEASE_CHECK
     data: EngineeringChangeReleaseCheckData

--- a/csfunctions/events/engineering_change_release_check.py
+++ b/csfunctions/events/engineering_change_release_check.py
@@ -8,8 +8,8 @@ from .base import BaseEvent, EventNames
 
 
 class EngineeringChangeReleaseCheckData(BaseModel):
-    attached_documents: list[Document] = Field(..., description="List of included documents.")
-    attached_parts: list[Part] = Field(..., description="List of included parts.")
+    documents: list[Document] = Field(..., description="List of included documents.")
+    parts: list[Part] = Field(..., description="List of included parts.")
     engineering_changes: list[EngineeringChange] = Field(
         ..., description="List of engineering changes that will be released."
     )

--- a/csfunctions/events/engineering_change_released.py
+++ b/csfunctions/events/engineering_change_released.py
@@ -7,7 +7,7 @@ from csfunctions.objects import Document, EngineeringChange, Part
 from .base import BaseEvent, EventNames
 
 
-class EngineeringChangeReleaseData(BaseModel):
+class EngineeringChangeReleasedData(BaseModel):
     documents: list[Document] = Field(..., description="List of included documents.")
     parts: list[Part] = Field(..., description="List of included parts.")
     engineering_changes: list[EngineeringChange] = Field(
@@ -15,6 +15,6 @@ class EngineeringChangeReleaseData(BaseModel):
     )
 
 
-class EngineeringChangeRelease(BaseEvent):
-    name: Literal[EventNames.ENGINEERING_CHANGE_RELEASE] = EventNames.ENGINEERING_CHANGE_RELEASE
-    data: EngineeringChangeReleaseData
+class EngineeringChangeReleasedEvent(BaseEvent):
+    name: Literal[EventNames.ENGINEERING_CHANGE_RELEASED] = EventNames.ENGINEERING_CHANGE_RELEASED
+    data: EngineeringChangeReleasedData

--- a/csfunctions/events/part_create_check.py
+++ b/csfunctions/events/part_create_check.py
@@ -9,7 +9,7 @@ from .base import BaseEvent, EventNames
 
 class PartCreateCheckData(BaseModel):
     parts: list[Part] = Field(..., description="List of parts that are about to be created")
-    linked_documents: list[Document] = Field(..., description="List of documents that are referenced by the parts.")
+    documents: list[Document] = Field(..., description="List of documents that are referenced by the parts.")
 
 
 class PartCreateCheckEvent(BaseEvent):

--- a/csfunctions/events/part_field_calculation.py
+++ b/csfunctions/events/part_field_calculation.py
@@ -11,7 +11,7 @@ class PartFieldCalculationData(BaseModel):
     part: Part = Field(..., description="Current state of the part")
     action: Literal["create", "modify", "copy", "index"] = Field(..., description="Action being performed")
 
-    linked_documents: list[Document] = Field(..., description="List of documents that are referenced by the parts.")
+    documents: list[Document] = Field(..., description="List of documents that are referenced by the parts.")
 
 
 class PartFieldCalculationEvent(BaseEvent):

--- a/csfunctions/events/part_modify_check.py
+++ b/csfunctions/events/part_modify_check.py
@@ -9,7 +9,7 @@ from .base import BaseEvent, EventNames
 
 class PartModifyCheckData(BaseModel):
     parts: list[Part] = Field(..., description="List of parts that are about to be modified")
-    linked_documents: list[Document] = Field(..., description="List of documents that are referenced by the parts.")
+    documents: list[Document] = Field(..., description="List of documents that are referenced by the parts.")
 
 
 class PartModifyCheckEvent(BaseEvent):

--- a/csfunctions/events/part_release_check.py
+++ b/csfunctions/events/part_release_check.py
@@ -10,7 +10,7 @@ from .dialog_data import PartReleasedDialogData
 
 class PartReleaseCheckData(BaseModel):
     parts: list[Part] = Field(..., description="List of parts that will be released.")
-    attached_documents: list[Document] = Field(..., description="List of documents that are referenced by the parts.")
+    documents: list[Document] = Field(..., description="List of documents that are referenced by the parts.")
     dialog_data: PartReleasedDialogData
 
 

--- a/csfunctions/events/part_release_check.py
+++ b/csfunctions/events/part_release_check.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel, Field
 from csfunctions.objects import Document, Part
 
 from .base import BaseEvent, EventNames
-from .dialog_data import PartReleaseDialogData
+from .dialog_data import PartReleasedDialogData
 
 
 class PartReleaseCheckData(BaseModel):
     parts: list[Part] = Field(..., description="List of parts that will be released.")
     attached_documents: list[Document] = Field(..., description="List of documents that are referenced by the parts.")
-    dialog_data: PartReleaseDialogData
+    dialog_data: PartReleasedDialogData
 
 
 class PartReleaseCheckEvent(BaseEvent):

--- a/csfunctions/events/part_released.py
+++ b/csfunctions/events/part_released.py
@@ -5,15 +5,15 @@ from pydantic import BaseModel, Field
 from csfunctions.objects import Document, Part
 
 from .base import BaseEvent, EventNames
-from .dialog_data import PartReleaseDialogData
+from .dialog_data import PartReleasedDialogData
 
 
-class PartReleaseData(BaseModel):
+class PartReleasedData(BaseModel):
     parts: list[Part] = Field(..., description="List if parts that were released.")
     documents: list[Document] = Field(..., description="List if documents that are referenced by the released part.")
-    dialog_data: PartReleaseDialogData
+    dialog_data: PartReleasedDialogData
 
 
-class PartReleaseEvent(BaseEvent):
-    name: Literal[EventNames.PART_RELEASE] = EventNames.PART_RELEASE
-    data: PartReleaseData
+class PartReleasedEvent(BaseEvent):
+    name: Literal[EventNames.PART_RELEASED] = EventNames.PART_RELEASED
+    data: PartReleasedData

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -18,7 +18,7 @@ The event is triggered before any field calculations are performed.
 |Attribute|Type|Description|
 |-|-|-|
 |documents| list[[Document](objects.md#document)]|List of documents that are about to be created.|
-|linked_parts| list[[Part](objects.md#part)]|List of parts that belong to the documents.|
+|parts| list[[Part](objects.md#part)]|List of parts that belong to the documents.|
 
 ## DocumentModifyCheckEvent
 `csfunctions.events.DocumentModifyCheckEvent`
@@ -37,7 +37,7 @@ The event is triggered before any field calculations are performed.
 |Attribute|Type|Description|
 |-|-|-|
 |documents| list[[Document](objects.md#document)]|List of documents that are about to be modified.|
-|linked_parts| list[[Part](objects.md#part)]|List of parts that belong to the documents.|
+|parts| list[[Part](objects.md#part)]|List of parts that belong to the documents.|
 
 
 ## DocumentReleaseCheckEvent
@@ -57,7 +57,7 @@ Be aware that the document is not released yet and the release might still be ab
 |Attribute|Type|Description|
 |-|-|-|
 |documents| list[[Document](objects.md#document)]|List of documents that will be released.|
-|attached_parts| list[[Part](objects.md#part)]|List of parts that belong to the documents.|
+|parts| list[[Part](objects.md#part)]|List of parts that belong to the documents.|
 |dialog_data|DocumentReleaseDialogData|Contents of the dialog.|
 
 **DocumentReleaseCheckDialogData:**
@@ -106,7 +106,7 @@ The event expects a DataResponse containing a dictionary of field names and thei
 |-|-|-|
 |document|[Document](objects.md#document)|Current state of the document|
 |action|Literal["create", "modify", "copy", "index"]|Action being performed|
-|linked_parts|list[[Part](objects.md#part)]|Parts that belong to the document|
+|parts|list[[Part](objects.md#part)]|Parts that belong to the document|
 
 
 
@@ -127,8 +127,8 @@ Be aware that the engineering change is not released yet and the release might s
 |Attribute|Type|Description|
 |-|-|-|
 |engineering_changes| list[[EngineeringChange](objects.md#engineeringchange)]|List of engineering changes that will be released.|
-|attached_documents| list[[Document](objects.md#document)]|List of included documents.|
-|attached_parts| list[[Part](objects.md#part)]|List of included parts.|
+|documents| list[[Document](objects.md#document)]|List of included documents.|
+|parts| list[[Part](objects.md#part)]|List of included parts.|
 
 
 ## EngineeringChangeReleasedEvent
@@ -163,7 +163,7 @@ The event is triggered before any field calculations are performed.
 |Attribute|Type|Description|
 |-|-|-|
 |parts| list[[Part](objects.md#part)]|List of parts that are about to be created.|
-|linked_documents| list[[Document](objects.md#document)]|List of documents that are referenced by the parts.|
+|documents| list[[Document](objects.md#document)]|List of documents that are referenced by the parts.|
 
 ## PartModifyCheckEvent
 `csfunctions.events.PartModifyCheckEvent`
@@ -182,7 +182,7 @@ The event is triggered before any field calculations are performed.
 |Attribute|Type|Description|
 |-|-|-|
 |parts| list[[Part](objects.md#part)]|List of parts that are about to be modified.|
-|linked_documents| list[[Document](objects.md#document)]|List of documents that are referenced by the parts.|
+|documents| list[[Document](objects.md#document)]|List of documents that are referenced by the parts.|
 
 ## PartReleaseCheckEvent
 `csfunctions.events.PartReleaseCheckEvent`
@@ -201,7 +201,7 @@ Be aware that the part is not released yet and the release might still be aborte
 |Attribute|Type|Description|
 |-|-|-|
 |parts| list[[Part](objects.md#part)]|List of parts that will released.|
-|attached_documents| list[[Document](objects.md#document)]|List of documents that belong to the released parts.|
+|documents| list[[Document](objects.md#document)]|List of documents that belong to the released parts.|
 |dialog_data|PartReleaseDialogData|Contents of the dialog.|
 
 **PartReleaseCheckDialogData:**
@@ -250,7 +250,7 @@ The event expects a DataResponse containing a dictionary of field names and thei
 |-|-|-|
 |part|[Part](objects.md#part)|Current state of the part|
 |action|Literal["create", "modify", "copy", "index"]|Action being performed|
-|linked_documents| list[[Document](objects.md#document)]|List of documents that belong to the part|
+|documents| list[[Document](objects.md#document)]|List of documents that belong to the part|
 
 
 ## WorkflowTaskTriggerEvent

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -67,14 +67,14 @@ Be aware that the document is not released yet and the release might still be ab
 |cdbprot_remark|str \| None | Remark|
 |cdb_ec_id|str \| None| Engineering Change ID|
 
-## DocumentReleaseEvent
-`csfunctions.events.DocumentReleaseEvent`
+## DocumentReleasedEvent
+`csfunctions.events.DocumentReleasedEvent`
 
 This event is fired **after** a document has been released. Raising an exception thus can not prevent the release.
 
-**DocumentReleaseEvent.name:** document_release
+**DocumentReleasedEvent.name:** document_released
 
-**DocumentReleaseEvent.data:**
+**DocumentReleasedEvent.data:**
 
 |Attribute|Type|Description|
 |-|-|-|
@@ -82,7 +82,7 @@ This event is fired **after** a document has been released. Raising an exception
 |parts| list[[Part](objects.md#part)]|List of parts that belong to the released documents.|
 |dialog_data|DocumentReleaseDialogData|Contents of the dialog.|
 
-**DocumentReleaseDialogData:**
+**DocumentReleasedDialogData:**
 
 |Attribute|Type|Description|
 |-|-|-|
@@ -131,14 +131,14 @@ Be aware that the engineering change is not released yet and the release might s
 |attached_parts| list[[Part](objects.md#part)]|List of included parts.|
 
 
-## EngineeringChangeRelease
-`csfunctions.events.EngineeringChangeRelease`
+## EngineeringChangeReleasedEvent
+`csfunctions.events.EngineeringChangeReleasedEvent`
 
 This event is fired **after** an engineering change has been released. Raising an exception thus can not prevent the release.
 
-**EngineeringChangeRelease.name:** engineering_change_release
+**EngineeringChangeReleasedEvent.name:** engineering_change_released
 
-**EngineeringChangeRelease.data:**
+**EngineeringChangeReleasedEvent.data:**
 
 |Attribute|Type|Description|
 |-|-|-|
@@ -212,22 +212,22 @@ Be aware that the part is not released yet and the release might still be aborte
 |cdb_ec_id|str \| None| Engineering Change ID|
 
 
-## PartReleaseEvent
-`csfunctions.events.PartReleaseEvent`
+## PartReleasedEvent
+`csfunctions.events.PartReleasedEvent`
 
 This event is fired **after** a part has been released. Raising an exception thus can not prevent the release.
 
-**PartReleaseEvent.name:** part_release
+**PartReleasedEvent.name:** part_released
 
-**PartReleaseEvent.data:**
+**PartReleasedEvent.data:**
 
 |Attribute|Type|Description|
 |-|-|-|
 |parts| list[[Part](objects.md#part)]|List of parts that were released.|
 |documents| list[[Document](objects.md#document)]|List of documents that belong to the released parts.|
-|dialog_data|PartReleaseDialogData|Contents of the dialog.|
+|dialog_data|PartReleasedDialogData|Contents of the dialog.|
 
-**PartReleaseDialogData:**
+**PartReleasedDialogData:**
 
 |Attribute|Type|Description|
 |-|-|-|

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -3,7 +3,8 @@ Breaking changes:
 - Changed the names of the events and their classes, to be more consistent:
   - `DocumentReleaseEvent` -> `DocumentReleasedEvent`
   - `PartReleaseEvent` -> `PartReleasedEvent`
-  - `EngineeringChangeReleaseEvent` -> `EngineeringChangeReleasedEvent`
+  - `EngineeringChangeRelease` -> `EngineeringChangeReleasedEvent`
+  - `EngineeringChangeCheck`> `EngineeringChangeCheckEvent`
 
 - Event data now consistently uses the attributes `parts` and `documents` instead of `linked_parts` or `attached_parts`
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,3 +1,11 @@
+### Version unreleased:
+Breaking changes:
+Changed the names of the events and their classes, to be more consistent:
+  - `DocumentReleaseEvent` -> `DocumentReleasedEvent`
+  - `PartReleaseEvent` -> `PartReleasedEvent`
+  - `EngineeringChangeReleaseEvent` -> `EngineeringChangeReleasedEvent`
+
+
 ### Version 0.11.0:
 - Feature: Added Document and Part field calculation events.
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,10 +1,11 @@
 ### Version unreleased:
 Breaking changes:
-Changed the names of the events and their classes, to be more consistent:
+- Changed the names of the events and their classes, to be more consistent:
   - `DocumentReleaseEvent` -> `DocumentReleasedEvent`
   - `PartReleaseEvent` -> `PartReleasedEvent`
   - `EngineeringChangeReleaseEvent` -> `EngineeringChangeReleasedEvent`
 
+- Event data now consistently uses the attributes `parts` and `documents` instead of `linked_parts` or `attached_parts`
 
 ### Version 0.11.1:
 - Fix: crash when using pydantic>=2.11

--- a/json_schemas/request.json
+++ b/json_schemas/request.json
@@ -741,18 +741,18 @@
           "title": "Documents",
           "type": "array"
         },
-        "linked_parts": {
+        "parts": {
           "description": "List of parts that belong to the documents",
           "items": {
             "$ref": "#/$defs/Part"
           },
-          "title": "Linked Parts",
+          "title": "Parts",
           "type": "array"
         }
       },
       "required": [
         "documents",
-        "linked_parts"
+        "parts"
       ],
       "title": "DocumentCreateCheckData",
       "type": "object"
@@ -798,19 +798,19 @@
           "title": "Action",
           "type": "string"
         },
-        "linked_parts": {
+        "parts": {
           "description": "Parts that belong to the document",
           "items": {
             "$ref": "#/$defs/Part"
           },
-          "title": "Linked Parts",
+          "title": "Parts",
           "type": "array"
         }
       },
       "required": [
         "document",
         "action",
-        "linked_parts"
+        "parts"
       ],
       "title": "DocumentFieldCalculationData",
       "type": "object"
@@ -849,18 +849,18 @@
           "title": "Documents",
           "type": "array"
         },
-        "linked_parts": {
+        "parts": {
           "description": "List of parts that belong to the documents",
           "items": {
             "$ref": "#/$defs/Part"
           },
-          "title": "Linked Parts",
+          "title": "Parts",
           "type": "array"
         }
       },
       "required": [
         "documents",
-        "linked_parts"
+        "parts"
       ],
       "title": "DocumentModifyCheckData",
       "type": "object"
@@ -899,21 +899,21 @@
           "title": "Documents",
           "type": "array"
         },
-        "attached_parts": {
+        "parts": {
           "description": "List of parts that belong to the documents",
           "items": {
             "$ref": "#/$defs/Part"
           },
-          "title": "Attached Parts",
+          "title": "Parts",
           "type": "array"
         },
         "dialog_data": {
-          "$ref": "#/$defs/DocumentReleaseDialogData"
+          "$ref": "#/$defs/DocumentReleasedDialogData"
         }
       },
       "required": [
         "documents",
-        "attached_parts",
+        "parts",
         "dialog_data"
       ],
       "title": "DocumentReleaseCheckData",
@@ -943,7 +943,37 @@
       "title": "DocumentReleaseCheckEvent",
       "type": "object"
     },
-    "DocumentReleaseDialogData": {
+    "DocumentReleasedData": {
+      "properties": {
+        "documents": {
+          "description": "List of documents that were released.",
+          "items": {
+            "$ref": "#/$defs/Document"
+          },
+          "title": "Documents",
+          "type": "array"
+        },
+        "parts": {
+          "description": "List of parts that belong to the released documents",
+          "items": {
+            "$ref": "#/$defs/Part"
+          },
+          "title": "Parts",
+          "type": "array"
+        },
+        "dialog_data": {
+          "$ref": "#/$defs/DocumentReleasedDialogData"
+        }
+      },
+      "required": [
+        "documents",
+        "parts",
+        "dialog_data"
+      ],
+      "title": "DocumentReleasedData",
+      "type": "object"
+    },
+    "DocumentReleasedDialogData": {
       "properties": {
         "dialog_type": {
           "const": "document_release",
@@ -978,37 +1008,7 @@
           "title": "Cdb Ec Id"
         }
       },
-      "title": "DocumentReleaseDialogData",
-      "type": "object"
-    },
-    "DocumentReleasedData": {
-      "properties": {
-        "documents": {
-          "description": "List of documents that were released.",
-          "items": {
-            "$ref": "#/$defs/Document"
-          },
-          "title": "Documents",
-          "type": "array"
-        },
-        "parts": {
-          "description": "List of parts that belong to the released documents",
-          "items": {
-            "$ref": "#/$defs/Part"
-          },
-          "title": "Parts",
-          "type": "array"
-        },
-        "dialog_data": {
-          "$ref": "#/$defs/DocumentReleaseDialogData"
-        }
-      },
-      "required": [
-        "documents",
-        "parts",
-        "dialog_data"
-      ],
-      "title": "DocumentReleasedData",
+      "title": "DocumentReleasedDialogData",
       "type": "object"
     },
     "DocumentReleasedEvent": {
@@ -1395,20 +1395,20 @@
     },
     "EngineeringChangeReleaseCheckData": {
       "properties": {
-        "attached_documents": {
+        "documents": {
           "description": "List of included documents.",
           "items": {
             "$ref": "#/$defs/Document"
           },
-          "title": "Attached Documents",
+          "title": "Documents",
           "type": "array"
         },
-        "attached_parts": {
+        "parts": {
           "description": "List of included parts.",
           "items": {
             "$ref": "#/$defs/Part"
           },
-          "title": "Attached Parts",
+          "title": "Parts",
           "type": "array"
         },
         "engineering_changes": {
@@ -1421,8 +1421,8 @@
         }
       },
       "required": [
-        "attached_documents",
-        "attached_parts",
+        "documents",
+        "parts",
         "engineering_changes"
       ],
       "title": "EngineeringChangeReleaseCheckData",
@@ -2594,18 +2594,18 @@
           "title": "Parts",
           "type": "array"
         },
-        "linked_documents": {
+        "documents": {
           "description": "List of documents that are referenced by the parts.",
           "items": {
             "$ref": "#/$defs/Document"
           },
-          "title": "Linked Documents",
+          "title": "Documents",
           "type": "array"
         }
       },
       "required": [
         "parts",
-        "linked_documents"
+        "documents"
       ],
       "title": "PartCreateCheckData",
       "type": "object"
@@ -2651,19 +2651,19 @@
           "title": "Action",
           "type": "string"
         },
-        "linked_documents": {
+        "documents": {
           "description": "List of documents that are referenced by the parts.",
           "items": {
             "$ref": "#/$defs/Document"
           },
-          "title": "Linked Documents",
+          "title": "Documents",
           "type": "array"
         }
       },
       "required": [
         "part",
         "action",
-        "linked_documents"
+        "documents"
       ],
       "title": "PartFieldCalculationData",
       "type": "object"
@@ -2702,18 +2702,18 @@
           "title": "Parts",
           "type": "array"
         },
-        "linked_documents": {
+        "documents": {
           "description": "List of documents that are referenced by the parts.",
           "items": {
             "$ref": "#/$defs/Document"
           },
-          "title": "Linked Documents",
+          "title": "Documents",
           "type": "array"
         }
       },
       "required": [
         "parts",
-        "linked_documents"
+        "documents"
       ],
       "title": "PartModifyCheckData",
       "type": "object"
@@ -2752,21 +2752,21 @@
           "title": "Parts",
           "type": "array"
         },
-        "attached_documents": {
+        "documents": {
           "description": "List of documents that are referenced by the parts.",
           "items": {
             "$ref": "#/$defs/Document"
           },
-          "title": "Attached Documents",
+          "title": "Documents",
           "type": "array"
         },
         "dialog_data": {
-          "$ref": "#/$defs/PartReleaseDialogData"
+          "$ref": "#/$defs/PartReleasedDialogData"
         }
       },
       "required": [
         "parts",
-        "attached_documents",
+        "documents",
         "dialog_data"
       ],
       "title": "PartReleaseCheckData",
@@ -2796,7 +2796,37 @@
       "title": "PartReleaseCheckEvent",
       "type": "object"
     },
-    "PartReleaseDialogData": {
+    "PartReleasedData": {
+      "properties": {
+        "parts": {
+          "description": "List if parts that were released.",
+          "items": {
+            "$ref": "#/$defs/Part"
+          },
+          "title": "Parts",
+          "type": "array"
+        },
+        "documents": {
+          "description": "List if documents that are referenced by the released part.",
+          "items": {
+            "$ref": "#/$defs/Document"
+          },
+          "title": "Documents",
+          "type": "array"
+        },
+        "dialog_data": {
+          "$ref": "#/$defs/PartReleasedDialogData"
+        }
+      },
+      "required": [
+        "parts",
+        "documents",
+        "dialog_data"
+      ],
+      "title": "PartReleasedData",
+      "type": "object"
+    },
+    "PartReleasedDialogData": {
       "properties": {
         "dialog_type": {
           "const": "part_release",
@@ -2831,37 +2861,7 @@
           "title": "Cdb Ec Id"
         }
       },
-      "title": "PartReleaseDialogData",
-      "type": "object"
-    },
-    "PartReleasedData": {
-      "properties": {
-        "parts": {
-          "description": "List if parts that were released.",
-          "items": {
-            "$ref": "#/$defs/Part"
-          },
-          "title": "Parts",
-          "type": "array"
-        },
-        "documents": {
-          "description": "List if documents that are referenced by the released part.",
-          "items": {
-            "$ref": "#/$defs/Document"
-          },
-          "title": "Documents",
-          "type": "array"
-        },
-        "dialog_data": {
-          "$ref": "#/$defs/PartReleaseDialogData"
-        }
-      },
-      "required": [
-        "parts",
-        "documents",
-        "dialog_data"
-      ],
-      "title": "PartReleasedData",
+      "title": "PartReleasedDialogData",
       "type": "object"
     },
     "PartReleasedEvent": {

--- a/json_schemas/request.json
+++ b/json_schemas/request.json
@@ -943,36 +943,6 @@
       "title": "DocumentReleaseCheckEvent",
       "type": "object"
     },
-    "DocumentReleaseData": {
-      "properties": {
-        "documents": {
-          "description": "List of documents that were released.",
-          "items": {
-            "$ref": "#/$defs/Document"
-          },
-          "title": "Documents",
-          "type": "array"
-        },
-        "parts": {
-          "description": "List of parts that belong to the released documents",
-          "items": {
-            "$ref": "#/$defs/Part"
-          },
-          "title": "Parts",
-          "type": "array"
-        },
-        "dialog_data": {
-          "$ref": "#/$defs/DocumentReleaseDialogData"
-        }
-      },
-      "required": [
-        "documents",
-        "parts",
-        "dialog_data"
-      ],
-      "title": "DocumentReleaseData",
-      "type": "object"
-    },
     "DocumentReleaseDialogData": {
       "properties": {
         "dialog_type": {
@@ -1011,11 +981,41 @@
       "title": "DocumentReleaseDialogData",
       "type": "object"
     },
-    "DocumentReleaseEvent": {
+    "DocumentReleasedData": {
+      "properties": {
+        "documents": {
+          "description": "List of documents that were released.",
+          "items": {
+            "$ref": "#/$defs/Document"
+          },
+          "title": "Documents",
+          "type": "array"
+        },
+        "parts": {
+          "description": "List of parts that belong to the released documents",
+          "items": {
+            "$ref": "#/$defs/Part"
+          },
+          "title": "Parts",
+          "type": "array"
+        },
+        "dialog_data": {
+          "$ref": "#/$defs/DocumentReleaseDialogData"
+        }
+      },
+      "required": [
+        "documents",
+        "parts",
+        "dialog_data"
+      ],
+      "title": "DocumentReleasedData",
+      "type": "object"
+    },
+    "DocumentReleasedEvent": {
       "properties": {
         "name": {
-          "const": "document_release",
-          "default": "document_release",
+          "const": "document_released",
+          "default": "document_released",
           "title": "Name",
           "type": "string"
         },
@@ -1025,14 +1025,14 @@
           "type": "string"
         },
         "data": {
-          "$ref": "#/$defs/DocumentReleaseData"
+          "$ref": "#/$defs/DocumentReleasedData"
         }
       },
       "required": [
         "event_id",
         "data"
       ],
-      "title": "DocumentReleaseEvent",
+      "title": "DocumentReleasedEvent",
       "type": "object"
     },
     "DummyEvent": {
@@ -1393,54 +1393,6 @@
       "title": "EngineeringChange",
       "type": "object"
     },
-    "EngineeringChangeRelease": {
-      "properties": {
-        "name": {
-          "const": "engineering_change_release",
-          "default": "engineering_change_release",
-          "title": "Name",
-          "type": "string"
-        },
-        "event_id": {
-          "description": "unique identifier",
-          "title": "Event Id",
-          "type": "string"
-        },
-        "data": {
-          "$ref": "#/$defs/EngineeringChangeReleaseData"
-        }
-      },
-      "required": [
-        "event_id",
-        "data"
-      ],
-      "title": "EngineeringChangeRelease",
-      "type": "object"
-    },
-    "EngineeringChangeReleaseCheck": {
-      "properties": {
-        "name": {
-          "const": "engineering_change_release_check",
-          "default": "engineering_change_release_check",
-          "title": "Name",
-          "type": "string"
-        },
-        "event_id": {
-          "description": "unique identifier",
-          "title": "Event Id",
-          "type": "string"
-        },
-        "data": {
-          "$ref": "#/$defs/EngineeringChangeReleaseCheckData"
-        }
-      },
-      "required": [
-        "event_id",
-        "data"
-      ],
-      "title": "EngineeringChangeReleaseCheck",
-      "type": "object"
-    },
     "EngineeringChangeReleaseCheckData": {
       "properties": {
         "attached_documents": {
@@ -1476,7 +1428,31 @@
       "title": "EngineeringChangeReleaseCheckData",
       "type": "object"
     },
-    "EngineeringChangeReleaseData": {
+    "EngineeringChangeReleaseCheckEvent": {
+      "properties": {
+        "name": {
+          "const": "engineering_change_release_check",
+          "default": "engineering_change_release_check",
+          "title": "Name",
+          "type": "string"
+        },
+        "event_id": {
+          "description": "unique identifier",
+          "title": "Event Id",
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/EngineeringChangeReleaseCheckData"
+        }
+      },
+      "required": [
+        "event_id",
+        "data"
+      ],
+      "title": "EngineeringChangeReleaseCheckEvent",
+      "type": "object"
+    },
+    "EngineeringChangeReleasedData": {
       "properties": {
         "documents": {
           "description": "List of included documents.",
@@ -1508,7 +1484,31 @@
         "parts",
         "engineering_changes"
       ],
-      "title": "EngineeringChangeReleaseData",
+      "title": "EngineeringChangeReleasedData",
+      "type": "object"
+    },
+    "EngineeringChangeReleasedEvent": {
+      "properties": {
+        "name": {
+          "const": "engineering_change_released",
+          "default": "engineering_change_released",
+          "title": "Name",
+          "type": "string"
+        },
+        "event_id": {
+          "description": "unique identifier",
+          "title": "Event Id",
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/$defs/EngineeringChangeReleasedData"
+        }
+      },
+      "required": [
+        "event_id",
+        "data"
+      ],
+      "title": "EngineeringChangeReleasedEvent",
       "type": "object"
     },
     "FieldValueCalculationData": {
@@ -2793,36 +2793,6 @@
       "title": "PartReleaseCheckEvent",
       "type": "object"
     },
-    "PartReleaseData": {
-      "properties": {
-        "parts": {
-          "description": "List if parts that were released.",
-          "items": {
-            "$ref": "#/$defs/Part"
-          },
-          "title": "Parts",
-          "type": "array"
-        },
-        "documents": {
-          "description": "List if documents that are referenced by the released part.",
-          "items": {
-            "$ref": "#/$defs/Document"
-          },
-          "title": "Documents",
-          "type": "array"
-        },
-        "dialog_data": {
-          "$ref": "#/$defs/PartReleaseDialogData"
-        }
-      },
-      "required": [
-        "parts",
-        "documents",
-        "dialog_data"
-      ],
-      "title": "PartReleaseData",
-      "type": "object"
-    },
     "PartReleaseDialogData": {
       "properties": {
         "dialog_type": {
@@ -2861,11 +2831,41 @@
       "title": "PartReleaseDialogData",
       "type": "object"
     },
-    "PartReleaseEvent": {
+    "PartReleasedData": {
+      "properties": {
+        "parts": {
+          "description": "List if parts that were released.",
+          "items": {
+            "$ref": "#/$defs/Part"
+          },
+          "title": "Parts",
+          "type": "array"
+        },
+        "documents": {
+          "description": "List if documents that are referenced by the released part.",
+          "items": {
+            "$ref": "#/$defs/Document"
+          },
+          "title": "Documents",
+          "type": "array"
+        },
+        "dialog_data": {
+          "$ref": "#/$defs/PartReleaseDialogData"
+        }
+      },
+      "required": [
+        "parts",
+        "documents",
+        "dialog_data"
+      ],
+      "title": "PartReleasedData",
+      "type": "object"
+    },
+    "PartReleasedEvent": {
       "properties": {
         "name": {
-          "const": "part_release",
-          "default": "part_release",
+          "const": "part_released",
+          "default": "part_released",
           "title": "Name",
           "type": "string"
         },
@@ -2875,14 +2875,14 @@
           "type": "string"
         },
         "data": {
-          "$ref": "#/$defs/PartReleaseData"
+          "$ref": "#/$defs/PartReleasedData"
         }
       },
       "required": [
         "event_id",
         "data"
       ],
-      "title": "PartReleaseEvent",
+      "title": "PartReleasedEvent",
       "type": "object"
     },
     "Workflow": {
@@ -3068,24 +3068,24 @@
           "document_create_check": "#/$defs/DocumentCreateCheckEvent",
           "document_field_calculation": "#/$defs/DocumentFieldCalculationEvent",
           "document_modify_check": "#/$defs/DocumentModifyCheckEvent",
-          "document_release": "#/$defs/DocumentReleaseEvent",
           "document_release_check": "#/$defs/DocumentReleaseCheckEvent",
+          "document_released": "#/$defs/DocumentReleasedEvent",
           "dummy": "#/$defs/DummyEvent",
-          "engineering_change_release": "#/$defs/EngineeringChangeRelease",
-          "engineering_change_release_check": "#/$defs/EngineeringChangeReleaseCheck",
+          "engineering_change_release_check": "#/$defs/EngineeringChangeReleaseCheckEvent",
+          "engineering_change_released": "#/$defs/EngineeringChangeReleasedEvent",
           "field_value_calculation": "#/$defs/FieldValueCalculationEvent",
           "part_create_check": "#/$defs/PartCreateCheckEvent",
           "part_field_calculation": "#/$defs/PartFieldCalculationEvent",
           "part_modify_check": "#/$defs/PartModifyCheckEvent",
-          "part_release": "#/$defs/PartReleaseEvent",
           "part_release_check": "#/$defs/PartReleaseCheckEvent",
+          "part_released": "#/$defs/PartReleasedEvent",
           "workflow_task_trigger": "#/$defs/WorkflowTaskTriggerEvent"
         },
         "propertyName": "name"
       },
       "oneOf": [
         {
-          "$ref": "#/$defs/DocumentReleaseEvent"
+          "$ref": "#/$defs/DocumentReleasedEvent"
         },
         {
           "$ref": "#/$defs/DocumentReleaseCheckEvent"
@@ -3094,7 +3094,7 @@
           "$ref": "#/$defs/DocumentFieldCalculationEvent"
         },
         {
-          "$ref": "#/$defs/PartReleaseEvent"
+          "$ref": "#/$defs/PartReleasedEvent"
         },
         {
           "$ref": "#/$defs/PartReleaseCheckEvent"
@@ -3109,10 +3109,10 @@
           "$ref": "#/$defs/DummyEvent"
         },
         {
-          "$ref": "#/$defs/EngineeringChangeRelease"
+          "$ref": "#/$defs/EngineeringChangeReleasedEvent"
         },
         {
-          "$ref": "#/$defs/EngineeringChangeReleaseCheck"
+          "$ref": "#/$defs/EngineeringChangeReleaseCheckEvent"
         },
         {
           "$ref": "#/$defs/WorkflowTaskTriggerEvent"

--- a/tests/events/test_ec_release.py
+++ b/tests/events/test_ec_release.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from unittest import TestCase
 
-from csfunctions.events import EngineeringChangeRelease, EngineeringChangeReleaseData
+from csfunctions.events import EngineeringChangeReleasedData, EngineeringChangeReleasedEvent
 from csfunctions.handler import link_objects
 from tests.utils import dummy_document, dummy_ec, dummy_part, dummy_request
 
@@ -15,10 +15,10 @@ class TestECRelease(TestCase):
 
         request = dummy_request
 
-        data = EngineeringChangeReleaseData(
+        data = EngineeringChangeReleasedData(
             documents=[document], parts=[part], engineering_changes=[engineering_change]
         )
-        event = EngineeringChangeRelease(event_id="123", data=data)
+        event = EngineeringChangeReleasedEvent(event_id="123", data=data)
         request.event = event
 
         # objects are not linked yet


### PR DESCRIPTION
Breaking changes:
- Changed the names of the events and their classes, to be more consistent:
  - `DocumentReleaseEvent` -> `DocumentReleasedEvent`
  - `PartReleaseEvent` -> `PartReleasedEvent`
  - `EngineeringChangeRelease` -> `EngineeringChangeReleasedEvent`

- Event data now consistently uses the attributes `parts` and `documents` instead of `linked_parts` or `attached_parts`