### PR TITLE
Feat: add reviewers field to release-check events

### DIFF
--- a/csfunctions/actions/start_workflow.py
+++ b/csfunctions/actions/start_workflow.py
@@ -2,14 +2,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from ..subject import Subject
 from .base import ActionNames, BaseAction
-
-
-class Subject(BaseModel):
-    subject_id: str = Field(..., description="ID of the subject, eg. a role name or personalnummer")
-    subject_type: Literal["Person", "PCS Role", "Common Role"] = Field(
-        ..., description="Type of the subject: Person, PCS Role or Common Role"
-    )
 
 
 class TaskConfiguration(BaseModel):

--- a/csfunctions/events/document_release_check.py
+++ b/csfunctions/events/document_release_check.py
@@ -3,6 +3,7 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 from csfunctions.objects import Document, Part
+from csfunctions.subject import Subject
 
 from .base import BaseEvent, EventNames
 from .dialog_data import DocumentReleasedDialogData
@@ -12,6 +13,10 @@ class DocumentReleaseCheckData(BaseModel):
     documents: list[Document] = Field(..., description="List of documents that will be released.")
     parts: list[Part] = Field(..., description="List of parts that belong to the documents")
     dialog_data: DocumentReleasedDialogData
+    reviewers: list[Subject] = Field(
+        default_factory=list,
+        description="List of reviewers assigned to the release. Only populated for express releases.",
+    )
 
 
 class DocumentReleaseCheckEvent(BaseEvent):

--- a/csfunctions/events/part_release_check.py
+++ b/csfunctions/events/part_release_check.py
@@ -3,6 +3,7 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 from csfunctions.objects import Document, Part
+from csfunctions.subject import Subject
 
 from .base import BaseEvent, EventNames
 from .dialog_data import PartReleasedDialogData
@@ -12,6 +13,10 @@ class PartReleaseCheckData(BaseModel):
     parts: list[Part] = Field(..., description="List of parts that will be released.")
     documents: list[Document] = Field(..., description="List of documents that are referenced by the parts.")
     dialog_data: PartReleasedDialogData
+    reviewers: list[Subject] = Field(
+        default_factory=list,
+        description="List of reviewers assigned to the release. Only populated for express releases.",
+    )
 
 
 class PartReleaseCheckEvent(BaseEvent):

--- a/csfunctions/subject.py
+++ b/csfunctions/subject.py
@@ -1,0 +1,10 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class Subject(BaseModel):
+    subject_id: str = Field(..., description="ID of the subject, eg. a role name or personalnummer")
+    subject_type: Literal["Person", "PCS Role", "Common Role"] = Field(
+        ..., description="Type of the subject: Person, PCS Role or Common Role"
+    )

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -54,11 +54,12 @@ Be aware that the document is not released yet and the release might still be ab
 
 **DocumentReleaseCheckEvent.data:**
 
-| Attribute   | Type                                  | Description                                 |
-| ----------- | ------------------------------------- | ------------------------------------------- |
-| documents   | list[[Document](objects.md#document)] | List of documents that will be released.    |
-| parts       | list[[Part](objects.md#part)]         | List of parts that belong to the documents. |
-| dialog_data | DocumentReleaseDialogData             | Contents of the dialog.                     |
+| Attribute   | Type                                  | Description                                                                     |
+| ----------- | ------------------------------------- | -------------------------------------------------------------------------------- |
+| documents   | list[[Document](objects.md#document)] | List of documents that will be released.                                        |
+| parts       | list[[Part](objects.md#part)]         | List of parts that belong to the documents.                                     |
+| dialog_data | DocumentReleaseDialogData             | Contents of the dialog.                                                          |
+| reviewers   | list[Subject]                         | List of reviewers assigned to the release. Only populated for express releases. |
 
 **DocumentReleaseCheckDialogData:**
 
@@ -66,6 +67,13 @@ Be aware that the document is not released yet and the release might still be ab
 | -------------- | ----------- | --------------------- |
 | cdbprot_remark | str \| None | Remark                |
 | cdb_ec_id      | str \| None | Engineering Change ID |
+
+**Subject:**
+
+| Attribute    | Type | Description                                                       |
+| ------------ | ---- | ------------------------------------------------------------------ |
+| subject_id   | str  | ID of the subject, e.g. a role name or "personalnummer"            |
+| subject_type | str  | Type of the subject. Can be "Person", "PCS Role" or "Common Role"  |
 
 ## DocumentReleasedEvent
 `csfunctions.events.DocumentReleasedEvent`
@@ -364,11 +372,12 @@ Be aware that the part is not released yet and the release might still be aborte
 
 **PartReleaseCheckEvent.data:**
 
-| Attribute   | Type                                  | Description                                          |
-| ----------- | ------------------------------------- | ---------------------------------------------------- |
-| parts       | list[[Part](objects.md#part)]         | List of parts that will released.                    |
-| documents   | list[[Document](objects.md#document)] | List of documents that belong to the released parts. |
-| dialog_data | PartReleaseDialogData                 | Contents of the dialog.                              |
+| Attribute   | Type                                  | Description                                                                     |
+| ----------- | ------------------------------------- | -------------------------------------------------------------------------------- |
+| parts       | list[[Part](objects.md#part)]         | List of parts that will released.                                              |
+| documents   | list[[Document](objects.md#document)] | List of documents that belong to the released parts.                           |
+| dialog_data | PartReleaseDialogData                 | Contents of the dialog.                                                          |
+| reviewers   | list[Subject]                         | List of reviewers assigned to the release. Only populated for express releases. |
 
 **PartReleaseCheckDialogData:**
 
@@ -376,6 +385,13 @@ Be aware that the part is not released yet and the release might still be aborte
 | -------------- | ----------- | --------------------- |
 | cdbprot_remark | str \| None | Remark                |
 | cdb_ec_id      | str \| None | Engineering Change ID |
+
+**Subject:**
+
+| Attribute    | Type | Description                                                       |
+| ------------ | ---- | ------------------------------------------------------------------ |
+| subject_id   | str  | ID of the subject, e.g. a role name or "personalnummer"            |
+| subject_type | str  | Type of the subject. Can be "Person", "PCS Role" or "Common Role"  |
 
 
 ## PartReleasedEvent

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -3,6 +3,9 @@ hide:
   - toc
 ---
 
+### Version 0.27.0
+- Feat: Add reviewers field to PartReleaseCheckEvent and DocumentReleaseCheckEvent, populated for express releases
+
 ### Version 0.26.0
 - Feat: Extend all multi-language object fields with Japanese (ja) and Chinese (zh) variants
 

--- a/json_schemas/request.json
+++ b/json_schemas/request.json
@@ -7413,6 +7413,14 @@
         },
         "dialog_data": {
           "$ref": "#/$defs/DocumentReleasedDialogData"
+        },
+        "reviewers": {
+          "description": "List of reviewers assigned to the release. Only populated for express releases.",
+          "items": {
+            "$ref": "#/$defs/Subject"
+          },
+          "title": "Reviewers",
+          "type": "array"
         }
       },
       "required": [
@@ -11137,6 +11145,14 @@
         },
         "dialog_data": {
           "$ref": "#/$defs/PartReleasedDialogData"
+        },
+        "reviewers": {
+          "description": "List of reviewers assigned to the release. Only populated for express releases.",
+          "items": {
+            "$ref": "#/$defs/Subject"
+          },
+          "title": "Reviewers",
+          "type": "array"
         }
       },
       "required": [
@@ -11261,6 +11277,31 @@
         "data"
       ],
       "title": "PartReleasedEvent",
+      "type": "object"
+    },
+    "Subject": {
+      "properties": {
+        "subject_id": {
+          "description": "ID of the subject, eg. a role name or personalnummer",
+          "title": "Subject Id",
+          "type": "string"
+        },
+        "subject_type": {
+          "description": "Type of the subject: Person, PCS Role or Common Role",
+          "enum": [
+            "Person",
+            "PCS Role",
+            "Common Role"
+          ],
+          "title": "Subject Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "subject_id",
+        "subject_type"
+      ],
+      "title": "Subject",
       "type": "object"
     },
     "Workflow": {


### PR DESCRIPTION
Add reviewers: list[Subject] to PartReleaseCheckData and DocumentReleaseCheckData, populated for express releases so Functions know who was assigned to review before the release proceeds.

