### PR TITLE
Feat: Add Role object (Common Roles only)

### DIFF
--- a/csfunctions/objects/__init__.py
+++ b/csfunctions/objects/__init__.py
@@ -5,12 +5,12 @@ from pydantic import Field
 from .base import BaseObject
 from .briefcase import Briefcase
 from .classification import ObjectPropertyValue
+from .common_role import CommonRole
 from .document import CADDocument, Document
 from .engineering_change import Change, ChangeOrder, ChangeRequest, EngineeringChange
 from .file import File
 from .part import BOMItem, Material, MaturityLevel, Part
 from .person import Person
-from .role import Role
 from .workflow import Workflow
 
 Object = Annotated[
@@ -28,7 +28,7 @@ Object = Annotated[
     | Workflow
     | Person
     | MaturityLevel
-    | Role,
+    | CommonRole,
     Field(discriminator="object_type"),
 ]
 
@@ -50,5 +50,5 @@ __all__ = [
     "BaseObject",
     "Person",
     "MaturityLevel",
-    "Role",
+    "CommonRole",
 ]

--- a/csfunctions/objects/__init__.py
+++ b/csfunctions/objects/__init__.py
@@ -10,6 +10,7 @@ from .engineering_change import Change, ChangeOrder, ChangeRequest, EngineeringC
 from .file import File
 from .part import BOMItem, Material, MaturityLevel, Part
 from .person import Person
+from .role import Role
 from .workflow import Workflow
 
 Object = Annotated[
@@ -26,7 +27,8 @@ Object = Annotated[
     | Briefcase
     | Workflow
     | Person
-    | MaturityLevel,
+    | MaturityLevel
+    | Role,
     Field(discriminator="object_type"),
 ]
 
@@ -48,4 +50,5 @@ __all__ = [
     "BaseObject",
     "Person",
     "MaturityLevel",
+    "Role",
 ]

--- a/csfunctions/objects/base.py
+++ b/csfunctions/objects/base.py
@@ -23,6 +23,7 @@ class ObjectType(str, Enum):
     BRIEFCASE = "briefcase"
     PERSON = "person"
     MATURITY_LEVEL = "maturity_level"
+    ROLE = "role"
 
 
 class BaseObject(BaseModel):

--- a/csfunctions/objects/base.py
+++ b/csfunctions/objects/base.py
@@ -23,7 +23,7 @@ class ObjectType(str, Enum):
     BRIEFCASE = "briefcase"
     PERSON = "person"
     MATURITY_LEVEL = "maturity_level"
-    ROLE = "role"
+    COMMON_ROLE = "common_role"
 
 
 class BaseObject(BaseModel):

--- a/csfunctions/objects/common_role.py
+++ b/csfunctions/objects/common_role.py
@@ -5,12 +5,12 @@ from pydantic import Field
 from csfunctions.objects.base import BaseObject, ObjectType
 
 
-class Role(BaseObject):
+class CommonRole(BaseObject):
     """
     A Common (global) Role that can be assigned to a Person.
     """
 
-    object_type: Literal[ObjectType.ROLE] = ObjectType.ROLE
+    object_type: Literal[ObjectType.COMMON_ROLE] = ObjectType.COMMON_ROLE
 
     role_id: str = Field(..., description="Role ID")
     name_de: str | None = Field(None, description="Name DE")

--- a/csfunctions/objects/role.py
+++ b/csfunctions/objects/role.py
@@ -1,0 +1,20 @@
+from typing import Literal
+
+from pydantic import Field
+
+from csfunctions.objects.base import BaseObject, ObjectType
+
+
+class Role(BaseObject):
+    """
+    A Common (global) Role that can be assigned to a Person.
+    """
+
+    object_type: Literal[ObjectType.ROLE] = ObjectType.ROLE
+
+    role_id: str = Field(..., description="Role ID")
+    name_de: str | None = Field(None, description="Name DE")
+    name_en: str | None = Field(None, description="Name EN")
+    name_ja: str | None = Field(None, description="Name JA")
+    name_zh: str | None = Field(None, description="Name ZH")
+    cdb_object_id: str | None = Field(None, description="Object ID")

--- a/docs/reference/objects.md
+++ b/docs/reference/objects.md
@@ -873,6 +873,20 @@ An objects property, used by classification.
 |e_mail|str \| None|Email|
 |telefon|str \| None|Phone|
 
+## Role
+`csfunctions.objects.Role`
+
+A Common (global) Role that can be assigned to a Person.
+
+|Attribute|Type|Description|
+|-|-|-|
+|role_id|str|Role ID|
+|name_de|str \| None|Name DE|
+|name_en|str \| None|Name EN|
+|name_ja|str \| None|Name JA|
+|name_zh|str \| None|Name ZH|
+|cdb_object_id|str \| None|Object ID|
+
 ## Workflow
 `csfunctions.objects.Workflow`
 

--- a/docs/reference/objects.md
+++ b/docs/reference/objects.md
@@ -246,6 +246,20 @@ A change request of the ECM module. Shares all attributes of its base class `csf
 |cdb_mpersno|str|Last Modified by|
 |cdb_mdate|datetime \| None|Last Modified on|
 
+## CommonRole
+`csfunctions.objects.CommonRole`
+
+A Common (global) Role that can be assigned to a Person.
+
+|Attribute|Type|Description|
+|-|-|-|
+|role_id|str|Role ID|
+|name_de|str \| None|Name DE|
+|name_en|str \| None|Name EN|
+|name_ja|str \| None|Name JA|
+|name_zh|str \| None|Name ZH|
+|cdb_object_id|str \| None|Object ID|
+
 ## Document
 `csfunctions.objects.Document`
 
@@ -872,20 +886,6 @@ An objects property, used by classification.
 |abt_nummer|str \| None|Department Number|
 |e_mail|str \| None|Email|
 |telefon|str \| None|Phone|
-
-## Role
-`csfunctions.objects.Role`
-
-A Common (global) Role that can be assigned to a Person.
-
-|Attribute|Type|Description|
-|-|-|-|
-|role_id|str|Role ID|
-|name_de|str \| None|Name DE|
-|name_en|str \| None|Name EN|
-|name_ja|str \| None|Name JA|
-|name_zh|str \| None|Name ZH|
-|cdb_object_id|str \| None|Object ID|
 
 ## Workflow
 `csfunctions.objects.Workflow`

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -3,6 +3,9 @@ hide:
   - toc
 ---
 
+### Version next
+- Feat: Add Role object (Common Roles only)
+
 ### Version 0.27.0
 - Feat: Add part_blocked and document_blocked events
 - Feat: Add reviewers field to PartReleaseCheckEvent and DocumentReleaseCheckEvent, populated for express releases

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,7 +4,7 @@ hide:
 ---
 
 ### Version next
-- Feat: Add Role object (Common Roles only)
+- Feat: Add CommonRole object
 
 ### Version 0.27.0
 - Feat: Add part_blocked and document_blocked events


### PR DESCRIPTION
Adds a new Role domain object representing a CONTACT Elements Common (global) Role, so consumers (e.g. functions-db-service) can expose which roles a Person has.